### PR TITLE
Remove old do_gettimeofday call

### DIFF
--- a/drivers/input/touchscreen/cyttsp5_device_access.c
+++ b/drivers/input/touchscreen/cyttsp5_device_access.c
@@ -1833,12 +1833,10 @@ int prepare_print_data(char *out_buf, int32_t *in_buf, int index, int data_num)
 
 int save_header(char *out_buf, int index, struct result *result)
 {
-	struct timex txc;
 	struct rtc_time tm;
 	char time_buf[100] = {0};
 
-	do_gettimeofday(&(txc.time));
-	rtc_time_to_tm(txc.time.tv_sec, &tm);
+	tm = rtc_ktime_to_tm(ktime_get_real());
 	scnprintf(time_buf, 100, "%d/%d/%d,TIME,%d:%d:%d,", tm.tm_year+1900,
 		 tm.tm_mon, tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec);
 


### PR DESCRIPTION
If enabling the sysfs interface there is an old call that needed updating in the source